### PR TITLE
Adjust alert deisplayed on the console

### DIFF
--- a/app/Traits/HttpResponses.php
+++ b/app/Traits/HttpResponses.php
@@ -14,7 +14,7 @@ trait HttpResponses
         ], $code);
     }
 
-    protected function error($data, $message = null, $code)
+    protected function error($data, $message = null, $code = Response::HTTP_INTERNAL_SERVER_ERROR)
     {
         return response()->json([
             'status' => 'Error has occurred',


### PR DESCRIPTION
PHP Deprecated:  Optional parameter $message declared before required parameter $code is implicitly treated as a required parameter